### PR TITLE
feat: abstract for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-lua-resty-ldap: ldap auth lib
-===========================================
+# lua-resty-ldap: ldap auth lib
 
 Access ldap server to do authentication via cosocket.
 
 This project is extracted from [kong](https://github.com/Kong/kong/tree/master/kong/plugins/ldap-auth).
 
-Installation
-------------
+## Installation
 
 The preferred way to install this library is to use Luarocks:
 
-    luarocks install lua-resty-ldap
+```shell
+luarocks install lua-resty-ldap
 
-Usage
------
+```
 
-### Synopsis
+## Synopsis
 
 ```lua
-local ldap = require "resty.ldap"
+local ldap = require("resty.ldap")
 local ldapconf = {
     timeout = 10000,
     start_tls = false,
@@ -33,16 +31,23 @@ local ldapconf = {
 local res, err = ldap.ldap_authenticate("john", "abc", ldapconf)
 ```
 
-### API
+```lua
+local ldap_client = require("resty.ldap.client")
+local client = ldap_client:new("127.0.0.1", 1389)
+local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "password1")
+```
 
-#### resty.ldap
+## Modules
+
+### resty.ldap
+
 To load this module:
 
-```
-local ldap = require "resty.ldap"
+```lua
+    local ldap = require "resty.ldap"
 ```
 
-#### ldap.ldap_authenticate
+#### ldap_authenticate
 
 **syntax:** *res, err = ldap.ldap_authenticate(username, password, ldapconf)*
 
@@ -59,3 +64,35 @@ local ldap = require "resty.ldap"
 | `attribute`      | string       | "cn"      | Attribute to be used to search the user; e.g., “cn”.       |
 | `timeout`      | number       | 10000      | An optional timeout in milliseconds when waiting for connection with LDAP server.       |
 | `keepalive`      | number       | 60000      | An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.       |
+
+### resty.ldap.client
+
+To load this module:
+
+```lua
+    local ldap_client = require "resty.ldap.client"
+```
+
+#### new
+
+**syntax:** *client = ldap_client:new(host, port, client_config?)*
+
+`client_config` is a table of below items, it is optional:
+
+| key      | type | default value      | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `socket_timeout`      | number       | 10000      | An optional timeout in milliseconds when waiting for connection with LDAP server.       |
+| `keepalive_timeout`   | number       | 60000      | An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.       |
+| `start_tls`      | boolean       | false      | Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over ldap connection. If the start_tls setting is enabled, ensure the ldaps setting is disabled.       |
+| `ldaps`      | boolean       | false      | Set to `true` to connect using the LDAPS protocol (LDAP over TLS). When ldaps is configured, you must use port 636. If the ldap setting is enabled, ensure the start_tls setting is disabled.       |
+| `ssl_verify`      | boolean       | false      | Set to true to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.       |
+
+#### simple_bind
+
+**syntax:** *err = client:simple_bind(bind_dn?, password?)*
+
+`bind_dn` is the full DN you need to bind.
+
+`password` is generally the `userPassword` field stored in that DN, but this is the mechanism implemented by the directory server.
+
+`bind_dn` and `password` can be `nil` values, that means the client is instructed to do anonymous bind.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ local res, err = ldap.ldap_authenticate("john", "abc", ldapconf)
 
 ```lua
 local ldap_client = require("resty.ldap.client")
-local client = ldap_client:new("127.0.0.1", 1389)
+local client = ldap_client:new("127.0.0.1", 1389, {
+    socket_timeout = 10000,
+    keepalive_timeout = 60000,
+    start_tls = false,
+    ldaps = false,
+    ssl_verify = false
+})
 local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "password1")
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ To load this module:
 
 #### simple_bind
 
-**syntax:** *err = client:simple_bind(bind_dn?, password?)*
+**syntax:** *res, err = client:simple_bind(bind_dn?, password?)*
 
 `bind_dn` is the full DN you need to bind.
 
 `password` is generally the `userPassword` field stored in that DN, but this is the mechanism implemented by the directory server.
 
 `bind_dn` and `password` can be `nil` values, that means the client is instructed to do anonymous bind.
+
+`res` is a boolean type value that will be true when authentication is successful, when it is false, `err` will contain errors.

--- a/lib/resty/ldap/asn1.lua
+++ b/lib/resty/ldap/asn1.lua
@@ -130,7 +130,7 @@ _M.get_object = asn1_get_object
 
 local function asn1_put_object(tag, class, constructed, data, len)
   len = type(data) == "string" and #data or len or 0
-  if len <= 0 then
+  if len < 0 then
     return nil, "invalid object length"
   end
 

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -127,8 +127,8 @@ end
 function _M.new(_, host, port, client_config)
     local opts = client_config or {}
     local socket_config = {
-        socket_timeout = opts.socket_timeout or 3000,
-        keepalive_timeout = opts.keepalive_timeout or (60 * 10 * 1000), -- 10 min
+        socket_timeout = opts.socket_timeout or 10000,
+        keepalive_timeout = opts.keepalive_timeout or (60 * 1000), -- 10 min
         -- keepalive_size = opts.keepalive_size or 2,
         start_tls = opts.start_tls or false,
         ldaps = opts.ldaps or false,

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -1,0 +1,173 @@
+local bunpack  = require "lua_pack".unpack
+local ldap     = require "resty.ldap.ldap"
+local protocol = require "resty.ldap.protocol"
+local asn1     = require "resty.ldap.asn1"
+
+local tostring = tostring
+local fmt      = string.format
+local log      = ngx.log
+local ERR      = ngx.ERR
+local tcp      = ngx.socket.tcp
+
+local asn1_parse_ldap_result = asn1.parse_ldap_result
+
+
+local _M = {}
+local mt = { __index = _M }
+
+
+local function calculate_payload_length(encStr, pos, socket)
+    local elen
+
+    pos, elen = bunpack(encStr, "C", pos)
+
+    if elen > 128 then
+        elen = elen - 128
+        local elenCalc = 0
+        local elenNext
+
+        for i = 1, elen do
+            elenCalc = elenCalc * 256
+            encStr = encStr .. socket:receive(1)
+            pos, elenNext = bunpack(encStr, "C", pos)
+            elenCalc = elenCalc + elenNext
+        end
+
+        elen = elenCalc
+    end
+
+    return pos, elen
+end
+
+local function _init_socket(self)
+    local host = self.host
+    local port = self.port
+    local socket_config = self.socket_config
+    local sock = tcp()
+
+    sock:settimeout(socket_config.socket_timeout)
+
+    -- keep TLS connections in a separate pool to avoid reusing non-secure
+    -- connections and vice-versa, because STARTTLS use the same port
+    local opts = {}
+    if socket_config.start_tls then
+        opts = {
+            pool = host .. ":" .. port .. ":starttls"
+        }
+    end
+
+    local ok, err = sock:connect(host, port, opts)
+    if not ok then
+        log(ERR, "failed to connect to ", host, ":",
+            tostring(port), ": ", err)
+        return err
+    end
+
+    if socket_config.start_tls then
+        -- convert connection to a STARTTLS connection only if it is a new connection
+        local count, err = sock:getreusedtimes()
+        if not count then
+            -- connection was closed, just return instead
+            return err
+        end
+
+        if count == 0 then
+            local ok, err = ldap.start_tls(sock)
+            if not ok then
+                return err
+            end
+        end
+    end
+
+    if socket_config.start_tls or socket_config.ldaps then
+        _, err = sock:sslhandshake(true, host, socket_config.ssl_verify)
+        if err ~= nil then
+            return fmt("failed to do SSL handshake with %s:%s: %s",
+                host, tostring(port), err)
+        end
+    end
+
+    self.socket = sock
+end
+
+local function _send(cli, request)
+    local bytes, err = cli.socket:send(request)
+    if not bytes then
+        return err
+    end
+end
+
+local function _send_recieve(cli, request)
+    local err = _send(cli, request)
+    if err then
+        return nil, err
+    end
+
+    local socket = cli.socket
+    local len, err = socket:receive(2)
+    if not len then
+        if err == "timeout" then
+            socket:close()
+            return nil, err
+        end
+        return nil, err
+    end
+
+    local _, packet_len = calculate_payload_length(len, 2, socket)
+    local packet = socket:receive(packet_len)
+
+    local res, err = asn1_parse_ldap_result(packet)
+    if err then
+        return nil, "Invalid LDAP message encoding: " .. err
+    end
+
+    return res
+end
+
+function _M.new(_, host, port, client_config)
+    local opts = client_config or {}
+    local socket_config = {
+        socket_timeout = opts.socket_timeout or 3000,
+        keepalive_timeout = opts.keepalive_timeout or (60 * 10 * 1000), -- 10 min
+        -- keepalive_size = opts.keepalive_size or 2,
+        start_tls = opts.start_tls or false,
+        ldaps = opts.ldaps or false,
+        ssl_verify = opts.ssl_verify or false,
+    }
+
+    local cli = setmetatable({
+        host = host,
+        port = port,
+        socket_config = socket_config,
+    }, mt)
+
+    local err = _init_socket(cli)
+    if err then
+        return nil, err
+    end
+
+    return cli
+end
+
+
+function _M.simple_bind(self, dn, password)
+    local res, err = _send_recieve(self, protocol.simple_bind_request(dn, password))
+    if not res then
+        return err
+    end
+
+    if res.protocol_op ~= protocol.APP_NO.BindResponse then
+        return fmt("Received incorrect Op in packet: %d, expected %d",
+            res.protocol_op, protocol.APP_NO.BindResponse)
+    end
+
+    if res.result_code ~= 0 then
+        local error_msg = protocol.ERROR_MSG[res.result_code]
+
+        return fmt("\n  Error: %s\n  Details: %s",
+            error_msg or ("Unknown error occurred (code: " .. res.result_code .. ")"),
+            res.diagnostic_msg or "")
+    end
+end
+
+return _M

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -157,21 +157,23 @@ end
 function _M.simple_bind(self, dn, password)
     local res, err = _send_recieve(self, protocol.simple_bind_request(dn, password))
     if not res then
-        return err
+        return false, err
     end
 
     if res.protocol_op ~= protocol.APP_NO.BindResponse then
-        return fmt("Received incorrect Op in packet: %d, expected %d",
+        return false, fmt("Received incorrect Op in packet: %d, expected %d",
             res.protocol_op, protocol.APP_NO.BindResponse)
     end
 
     if res.result_code ~= 0 then
         local error_msg = protocol.ERROR_MSG[res.result_code]
 
-        return fmt("\n  Error: %s\n  Details: %s",
+        return false, fmt("\n  Error: %s\n  Details: %s",
             error_msg or ("Unknown error occurred (code: " .. res.result_code .. ")"),
             res.diagnostic_msg or "")
     end
+
+    return true
 end
 
 return _M

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -125,6 +125,10 @@ local function _send_recieve(cli, request)
 end
 
 function _M.new(_, host, port, client_config)
+    if not host or not port then
+        return nil, "host and port cannot be nil"
+    end
+
     local opts = client_config or {}
     local socket_config = {
         socket_timeout = opts.socket_timeout or 10000,

--- a/lib/resty/ldap/protocol.lua
+++ b/lib/resty/ldap/protocol.lua
@@ -1,3 +1,4 @@
+local string_char     = string.char
 local asn1            = require "resty.ldap.asn1"
 local asn1_put_object = asn1.put_object
 local asn1_encode     = asn1.encode
@@ -34,17 +35,19 @@ local function ldap_message(app_no, req)
     return ldapMsg
 end
 
+
 function _M.simple_bind_request(dn, password)
     local ldapAuth = asn1_put_object(0, asn1.CLASS.CONTEXT_SPECIFIC, 0, password or "")
     if not password then
         -- When password is nil, ASN1_put_object does not generate a zero length for it,
         -- so we need to fill it in manually.
         -- This is a compatibility measure for anonymous bind.
-        ldapAuth = ldapAuth .. string.char(0)
+        ldapAuth = ldapAuth .. string_char(0)
     end
     local bindReq = asn1_encode(3) .. asn1_encode(dn or "") .. ldapAuth
     local ldapMsg = ldap_message(_M.APP_NO.BindRequest, bindReq)
     return asn1_encode(ldapMsg, asn1.TAG.SEQUENCE)
 end
+
 
 return _M

--- a/lib/resty/ldap/protocol.lua
+++ b/lib/resty/ldap/protocol.lua
@@ -1,0 +1,50 @@
+local asn1            = require "resty.ldap.asn1"
+local asn1_put_object = asn1.put_object
+local asn1_encode     = asn1.encode
+
+
+local _M = {}
+
+local ldapMessageId = 1
+
+_M.ERROR_MSG = {
+    [1]  = "Initialization of LDAP library failed.",
+    [4]  = "Size limit exceeded.",
+    [13] = "Confidentiality required",
+    [32] = "No such object",
+    [34] = "Invalid DN",
+    [49] = "The supplied credential is invalid."
+}
+
+_M.APP_NO = {
+    BindRequest = 0,
+    BindResponse = 1,
+    UnbindRequest = 2,
+    ExtendedRequest = 23,
+    ExtendedResponse = 24
+}
+
+
+local function ldap_message(app_no, req)
+    local ldapMsg = asn1_encode(ldapMessageId) ..
+        asn1_put_object(app_no, asn1.CLASS.APPLICATION, 1, req)
+
+    ldapMessageId = ldapMessageId + 1
+
+    return ldapMsg
+end
+
+function _M.simple_bind_request(dn, password)
+    local ldapAuth = asn1_put_object(0, asn1.CLASS.CONTEXT_SPECIFIC, 0, password or "")
+    if not password then
+        -- When password is nil, ASN1_put_object does not generate a zero length for it,
+        -- so we need to fill it in manually.
+        -- This is a compatibility measure for anonymous bind.
+        ldapAuth = ldapAuth .. string.char(0)
+    end
+    local bindReq = asn1_encode(3) .. asn1_encode(dn or "") .. ldapAuth
+    local ldapMsg = ldap_message(_M.APP_NO.BindRequest, bindReq)
+    return asn1_encode(ldapMsg, asn1.TAG.SEQUENCE)
+end
+
+return _M

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -22,7 +22,7 @@ __DATA__
         content_by_lua_block {
             local ldap_client = require "resty.ldap.client"
 
-            local client = ldap_client:new("127.0.0.1", 1389, {})
+            local client = ldap_client:new("127.0.0.1", 1389)
             local err = client:simple_bind()
             if err then
                 ngx.log(ngx.ERR, err)
@@ -45,8 +45,8 @@ GET /t
         content_by_lua_block {
             local ldap_client = require "resty.ldap.client"
 
-            local client = ldap_client:new("127.0.0.1", 1389, {})
-            local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "password1")
+            local client = ldap_client:new("127.0.0.1", 1389)
+            local err = client:simple_bind("cn=john,ou=users,dc=example,dc=org", "abc")
             if err then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
@@ -68,7 +68,7 @@ GET /t
         content_by_lua_block {
             local ldap_client = require "resty.ldap.client"
 
-            local client = ldap_client:new("127.0.0.1", 1389, {})
+            local client = ldap_client:new("127.0.0.1", 1389)
             local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "invalid_password")
             if err then
                 ngx.log(ngx.ERR, err)

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -81,3 +81,72 @@ GET /t
 --- error_log
 Error: The supplied credential is invalid.
 --- error_code: 401
+
+
+
+=== TEST 4: ldaps
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1636, { ldaps = true })
+            local err = client:simple_bind()
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 5: starttls
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1389, { start_tls = true })
+            local err = client:simple_bind()
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 6: ldaps (verify server certificate)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1636, { ldaps = true, ssl_verify = true })
+            local err = client:simple_bind()
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -134,6 +134,7 @@ GET /t
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
+        lua_ssl_trusted_certificate ../../certs/mycacert.crt;
         content_by_lua_block {
             local ldap_client = require "resty.ldap.client"
 

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -138,7 +138,7 @@ GET /t
         content_by_lua_block {
             local ldap_client = require "resty.ldap.client"
 
-            local client = ldap_client:new("127.0.0.1", 1636, { ldaps = true, ssl_verify = true })
+            local client = ldap_client:new("localhost", 1636, { ldaps = true, ssl_verify = true })
             local err = client:simple_bind()
             if err then
                 ngx.log(ngx.ERR, err)

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -1,0 +1,83 @@
+use Test::Nginx::Socket::Lua;
+
+log_level('info');
+no_shuffle();
+no_long_string();
+repeat_each(1);
+plan 'no_plan';
+
+our $HttpConfig = <<'_EOC_';
+    lua_package_path 'lib/?.lua;lib/?/init.lua;/usr/local/share/lua/5.3/?.lua;/usr/share/lua/5.1/?.lua;;';
+    resolver 127.0.0.53;
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: anonymous auth (simple bind with empty dn and password)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1389, {})
+            local err = client:simple_bind()
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 2: simple bind auth (ok)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1389, {})
+            local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "password1")
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 3: simple bind auth (invalid credential)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local ldap_client = require "resty.ldap.client"
+
+            local client = ldap_client:new("127.0.0.1", 1389, {})
+            local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "invalid_password")
+            if err then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(401)
+            end
+        }
+    }
+--- request
+GET /t
+--- error_log
+Error: The supplied credential is invalid.
+--- error_code: 401

--- a/t/ldap2.t
+++ b/t/ldap2.t
@@ -23,8 +23,8 @@ __DATA__
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("127.0.0.1", 1389)
-            local err = client:simple_bind()
-            if err then
+            local res, err = client:simple_bind()
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end
@@ -46,8 +46,8 @@ GET /t
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("127.0.0.1", 1389)
-            local err = client:simple_bind("cn=john,ou=users,dc=example,dc=org", "abc")
-            if err then
+            local res, err = client:simple_bind("cn=john,ou=users,dc=example,dc=org", "abc")
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end
@@ -69,8 +69,8 @@ GET /t
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("127.0.0.1", 1389)
-            local err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "invalid_password")
-            if err then
+            local res, err = client:simple_bind("cn=user01,ou=users,dc=example,dc=org", "invalid_password")
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end
@@ -92,8 +92,8 @@ Error: The supplied credential is invalid.
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("127.0.0.1", 1636, { ldaps = true })
-            local err = client:simple_bind()
-            if err then
+            local res, err = client:simple_bind()
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end
@@ -115,8 +115,8 @@ GET /t
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("127.0.0.1", 1389, { start_tls = true })
-            local err = client:simple_bind()
-            if err then
+            local res, err = client:simple_bind()
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end
@@ -139,8 +139,8 @@ GET /t
             local ldap_client = require "resty.ldap.client"
 
             local client = ldap_client:new("localhost", 1636, { ldaps = true, ssl_verify = true })
-            local err = client:simple_bind()
-            if err then
+            local res, err = client:simple_bind()
+            if not res then
                 ngx.log(ngx.ERR, err)
                 ngx.exit(401)
             end


### PR DESCRIPTION
Provides an abstract wrapper around the LDAP client. It uses the `new`, `doXXX` API to complete the functionality. Also, it now supports anonymous bind and simple bind.

- Implementing the client
- Decoupling codec and socket operations
- Testing of the new API

This is a completely new implementation, detached from part of the old one, and fixes some problems (anonymous bind)