### PR TITLE
feat: support filter compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           sudo docker run hello-world
 
           sudo apt -y install lua5.1 luarocks
-          sudo luarocks install lua_pack lpeg
+          sudo luarocks install lua_pack
+          sudo luarocks install lpeg
 
       - name: script
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           sudo docker run hello-world
 
           sudo apt -y install lua5.1 luarocks
-          sudo luarocks install lua_pack
+          sudo luarocks install lua_pack lpeg
 
       - name: script
         run: |

--- a/lib/resty/ldap/filter.lua
+++ b/lib/resty/ldap/filter.lua
@@ -1,0 +1,156 @@
+local lpeg = require('lpeg')
+local P, R, S, V = lpeg.P, lpeg.R, lpeg.S, lpeg.V
+local C, Ct, Cmt, Cg, Cc, Cf, Cmt = lpeg.C, lpeg.Ct, lpeg.Cmt, lpeg.Cg, lpeg.Cc, lpeg.Cf, lpeg.Cmt
+local locale = lpeg.locale()
+
+local next = next
+local string_char = string.char
+local table_insert = table.insert
+
+local _M = {}
+
+-- Const
+_M.OP_TYPE_AND = 'and'
+_M.OP_TYPE_OR = 'or'
+_M.OP_TYPE_NOT = 'not'
+_M.ITEM_TYPE_SUBSTRING = 'substring'
+_M.ITEM_TYPE_SIMPLE = 'simple'
+_M.ITEM_TYPE_PRESENT = 'present'
+_M.FILTER_TYPE_EQUAL = 'equal'
+_M.FILTER_TYPE_APPROX = 'approx'
+_M.FILTER_TYPE_GREATER = 'greater'
+_M.FILTER_TYPE_LESS = 'less'
+
+
+local function pack(...)
+    return { n = select('#', ...), ... }
+end
+
+-- Utility
+local _= V
+
+local function maybe(pattern)
+    if type(pattern) == 'string' then pattern = V(pattern) end
+    return pattern ^ -1
+end
+
+local function list(pattern, min)
+    if type(pattern) == 'string' then pattern = V(pattern) end
+    return Ct((pattern) ^ (min or 0))
+end
+
+-- Formatters
+local cOPBody = function (op_type, ...)
+    return {
+        op_type = op_type,
+        items = (...)[1] ~= nil and (...) or {...}
+    }
+end
+
+local cItemBody = function (item_type, ...)
+    local args = pack(...)
+    return {
+        item_type = item_type,
+        attribute_description = args[1].attribute_description,
+        filter_type = args[2].filter_type,
+        attribute_value = args[3].attribute_value,
+    }
+end
+
+-- Simple types
+local rawValue = (P'_' + R('az', 'AZ')) * (P'_' + R '09' + R('az', 'AZ')) ^ 0
+
+-- Grammar
+local filter = P{
+    _'FILTER' / function (f)
+        return f
+    end,
+    FILTER = _'FILL' * P'(' * _'OP' * P')' * _'FILL' / function(f)
+        return f
+    end,
+
+    OP= (_'OP_AND' + _'OP_OR' + _'OP_NOT' + _'ITEM'),
+    OP_AND = (P'&' * _'FILL' * list('FILTER', 1) * _'FILL') / function(...)
+        return cOPBody(_M.OP_TYPE_AND, ...)
+    end,
+    OP_OR = (P'|' * _'FILL' * list('FILTER', 1) * _'FILL') / function(...)
+        return cOPBody(_M.OP_TYPE_OR, ...)
+    end,
+    OP_NOT = 
+        (P'!' * (
+            (_'FILL' * _'FILTER' * _'FILL') +
+            (_'FILL' * _'ITEM' * _'FILL')
+        )) / function(...)
+            return cOPBody(_M.OP_TYPE_NOT, ...)
+        end,
+    ITEM = _'ITEM_SUBSTRING' +  _'ITEM_SIMPLE' + _'ITEM_PRESENT',
+    ITEM_SUBSTRING = (_'ATTRIBUTE_DESCRIPTION' * _'FILTER_TYPE_EQUAL' * _'ATTRIBUTE_VALUE_SUBSTRING') / function(...)
+        return cItemBody(_M.ITEM_TYPE_SUBSTRING, ...)
+    end,
+    ITEM_SIMPLE = _'ATTRIBUTE_DESCRIPTION' * _'FILTER_TYPE' * _'ATTRIBUTE_VALUE' / function(...)
+        return cItemBody(_M.ITEM_TYPE_SIMPLE, ...)
+    end,
+    ITEM_PRESENT = _'ATTRIBUTE_DESCRIPTION' * P'=*' / function (value)
+        return cItemBody(
+            _M.ITEM_TYPE_PRESENT, value,
+            { filter_type = _M.FILTER_TYPE_EQUAL },
+            { attribute_value = "*" }
+        )
+    end,
+    FILTER_TYPE = _'FILTER_TYPE_EQUAL' + _'FILTER_TYPE_APPROX' + _'FILTER_TYPE_GREATER' + _'FILTER_TYPE_LESS',
+    FILTER_TYPE_EQUAL = P'=' / function()
+        return { filter_type = _M.FILTER_TYPE_EQUAL }
+    end,
+    FILTER_TYPE_APPROX = P'~=' / function()
+        return { filter_type = _M.FILTER_TYPE_APPROX }
+    end,
+    FILTER_TYPE_GREATER = P'>=' / function()
+        return { filter_type = _M.FILTER_TYPE_GREATER }
+    end,
+    FILTER_TYPE_LESS = P'<=' / function()
+        return { filter_type = _M.FILTER_TYPE_LESS }
+    end,
+
+    ATTRIBUTE_DESCRIPTION = rawValue / function(value)
+        return { attribute_description = value }
+    end,
+    ATTRIBUTE_VALUE = rawValue / function(value)
+        return { attribute_value = value }
+    end,
+    ATTRIBUTE_VALUE_SUBSTRING =
+        ((_'ATTRIBUTE_VALUE' * _'WILDCARD') +
+        (_'WILDCARD' * _'ATTRIBUTE_VALUE' * _'WILDCARD') +
+        (_'WILDCARD' * _'ATTRIBUTE_VALUE')) / function(...)
+            local args = pack(...)
+            local s = ''
+            for i = 1, args.n, 1 do
+                local value = args[i]
+                if type(value) == "table" then
+                    s = s .. value.attribute_value
+                else
+                    s = s .. value
+                end
+            end
+            return { attribute_value = s }
+        end,
+
+    WILDCARD = P'*' / '*',
+    FILL = list(_'SPACE' + _'TAB' + _'SEP', 0) / function() end,
+    SPACE = P(string_char(0x20)),
+    TAB = P(string_char(0x09)),
+    SEP= (_'CR' * _'LF') + _'CR' + _'LF',
+    CR = P'\r',
+    LF = P'\n',
+}
+
+
+function _M.compile(str)
+    local result = filter:match(str)
+    if result then
+        return result
+    end
+    return nil, 'syntax error'
+end
+
+
+return _M

--- a/lib/resty/ldap/filter.lua
+++ b/lib/resty/ldap/filter.lua
@@ -26,8 +26,6 @@ local function pack(...)
 end
 
 -- Utility
-local _= V
-
 local function maybe(pattern)
     if type(pattern) == 'string' then pattern = V(pattern) end
     return pattern ^ -1
@@ -61,39 +59,39 @@ local rawValue = (P'_' + R('az', 'AZ')) * (P'_' + R '09' + R('az', 'AZ')) ^ 0
 
 -- Grammar
 local filter = P{
-    _'FILTER' / function(f)
+    V'FILTER' / function(f)
         return f
     end,
-    FILTER = _'FILL' * P'(' * _'OP' * P')' * _'FILL' / function(f)
+    FILTER = V'FILL' * P'(' * V'OP' * P')' * V'FILL' / function(f)
         return f
     end,
 
-    OP= (_'OP_AND' + _'OP_OR' + _'OP_NOT' + _'ITEM'),
-    OP_AND = (P'&' * _'FILL' * list('FILTER', 1) * _'FILL') / function(...)
+    OP= (V'OP_AND' + V'OP_OR' + V'OP_NOT' + V'ITEM'),
+    OP_AND = (P'&' * V'FILL' * list('FILTER', 1) * V'FILL') / function(...)
         return cOPBody(_M.OP_TYPE_AND, ...)
     end,
-    OP_OR = (P'|' * _'FILL' * list('FILTER', 1) * _'FILL') / function(...)
+    OP_OR = (P'|' * V'FILL' * list('FILTER', 1) * V'FILL') / function(...)
         return cOPBody(_M.OP_TYPE_OR, ...)
     end,
     OP_NOT =
-        (P'!' * _'FILL' * _'FILTER' * _'FILL') / function(...)
+        (P'!' * V'FILL' * V'FILTER' * V'FILL') / function(...)
             return cOPBody(_M.OP_TYPE_NOT, ...)
         end,
-    ITEM = _'ITEM_SUBSTRING' +  _'ITEM_SIMPLE' + _'ITEM_PRESENT',
-    ITEM_SUBSTRING = (_'ATTRIBUTE_DESCRIPTION' * _'FILTER_TYPE_EQUAL' * _'ATTRIBUTE_VALUE_SUBSTRING') / function(...)
+    ITEM = V'ITEM_SUBSTRING' +  V'ITEM_SIMPLE' + V'ITEM_PRESENT',
+    ITEM_SUBSTRING = (V'ATTRIBUTE_DESCRIPTION' * V'FILTER_TYPE_EQUAL' * V'ATTRIBUTE_VALUE_SUBSTRING') / function(...)
         return cItemBody(_M.ITEM_TYPE_SUBSTRING, ...)
     end,
-    ITEM_SIMPLE = _'ATTRIBUTE_DESCRIPTION' * _'FILTER_TYPE' * _'ATTRIBUTE_VALUE' / function(...)
+    ITEM_SIMPLE = V'ATTRIBUTE_DESCRIPTION' * V'FILTER_TYPE' * V'ATTRIBUTE_VALUE' / function(...)
         return cItemBody(_M.ITEM_TYPE_SIMPLE, ...)
     end,
-    ITEM_PRESENT = _'ATTRIBUTE_DESCRIPTION' * P'=*' / function(value)
+    ITEM_PRESENT = V'ATTRIBUTE_DESCRIPTION' * P'=*' / function(value)
         return cItemBody(
             _M.ITEM_TYPE_PRESENT, value,
             { filter_type = _M.FILTER_TYPE_EQUAL },
             { attribute_value = "*" }
         )
     end,
-    FILTER_TYPE = _'FILTER_TYPE_EQUAL' + _'FILTER_TYPE_APPROX' + _'FILTER_TYPE_GREATER' + _'FILTER_TYPE_LESS',
+    FILTER_TYPE = V'FILTER_TYPE_EQUAL' + V'FILTER_TYPE_APPROX' + V'FILTER_TYPE_GREATER' + V'FILTER_TYPE_LESS',
     FILTER_TYPE_EQUAL = P'=' / function()
         return { filter_type = _M.FILTER_TYPE_EQUAL }
     end,
@@ -114,9 +112,9 @@ local filter = P{
         return { attribute_value = value }
     end,
     ATTRIBUTE_VALUE_SUBSTRING =
-        ((_'ATTRIBUTE_VALUE' * _'WILDCARD') +
-        (_'WILDCARD' * _'ATTRIBUTE_VALUE' * _'WILDCARD') +
-        (_'WILDCARD' * _'ATTRIBUTE_VALUE')) / function(...)
+        ((V'ATTRIBUTE_VALUE' * V'WILDCARD') +
+        (V'WILDCARD' * V'ATTRIBUTE_VALUE' * V'WILDCARD') +
+        (V'WILDCARD' * V'ATTRIBUTE_VALUE')) / function(...)
             local s = {}
             for _, value in ipairs({...}) do
                 table_insert(s, type(value) == "table" and value.attribute_value or value)
@@ -125,12 +123,12 @@ local filter = P{
         end,
 
     WILDCARD = P'*' / '*',
-    FILL = list(_'SPACE' + _'TAB' + _'SEP', 0) / function() end,
-    SPACE = P(string_char(0x20)),
-    TAB = P(string_char(0x09)),
-    SEP= (_'CR' * _'LF') + _'CR' + _'LF',
-    CR = P'\r',
-    LF = P'\n',
+    FILL = list(V'SPACE' + V'TAB' + V'SEP', 0) / function() end,
+    SPACE = P(string_char(0x20)),         -- ASCII control charactor - Space
+    TAB = P(string_char(0x09)),           -- ASCII control charactor - TAB
+    SEP= (V'CR' * V'LF') + V'CR' + V'LF', -- ASCII control charactor - CR/LF/CRLF
+    CR = P'\r',                           -- ASCII control charactor - CR
+    LF = P'\n',                           -- ASCII control charactor - LF
 }
 
 

--- a/lib/resty/ldap/filter.lua
+++ b/lib/resty/ldap/filter.lua
@@ -116,8 +116,9 @@ local filter = P{
         (V'WILDCARD' * V'ATTRIBUTE_VALUE' * V'WILDCARD') +
         (V'WILDCARD' * V'ATTRIBUTE_VALUE')) / function(...)
             local s = {}
-            for _, value in ipairs({...}) do
-                table_insert(s, type(value) == "table" and value.attribute_value or value)
+            for i = 1, select('#', ...) do
+                local v = select(i, ...)
+                table_insert(s, type(v) == "table" and v.attribute_value or v)
             end
             return { attribute_value = table_concat(s) }
         end,

--- a/rockspec/lua-resty-ldap-main-0.rockspec
+++ b/rockspec/lua-resty-ldap-main-0.rockspec
@@ -1,5 +1,5 @@
-package = "lua-resty-ldap-main"
-version = "0.1-0"
+package = "lua-resty-ldap"
+version = "main-0"
 source = {
    url = "git://github.com/api7/lua-resty-ldap",
    branch = "main",
@@ -14,6 +14,7 @@ description = {
 
 dependencies = {
    "lua_pack = 2.0.0-0"
+   "lpeg = 1.0.2-1"
 }
 
 build = {

--- a/t/filter.t
+++ b/t/filter.t
@@ -119,16 +119,6 @@ GET /t
 
             local cases = {
                 {
-                    filter = '(!objectClass=posixAccount)',
-                    test = (function(f, m)
-                        -- {"op_type":"not","items":[{"attribute_value":"posixAccount","item_type":"simple","attribute_description":"objectClass","filter_type":"equal"}]}
-                        assert(f.op_type and f.op_type == 'not', m .. 'op_type != not, ' .. f.op_type)
-                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
-                        assert(f.items[1] ~= nil, m .. 'items not a object table')
-                        assert(f.items[1].attribute_value == 'posixAccount', m .. 'items[1].attribute_value != posixAccount, ' .. f.items[1].attribute_value)
-                    end)
-                },
-                {
                     filter = '(!(objectClass=posixAccount))',
                     test = (function(f, m)
                         -- {"op_type":"not","items":[{"attribute_value":"posixAccount","item_type":"simple","attribute_description":"objectClass","filter_type":"equal"}]}
@@ -167,7 +157,7 @@ GET /t
                         (&
                             (objectClass=posixAccount)
                             (uid=*)
-                            (!cn=user01)
+                            (!(cn=user01))
                         )
                     ]],
                     test = (function(f, m)

--- a/t/filter.t
+++ b/t/filter.t
@@ -1,0 +1,198 @@
+use Test::Nginx::Socket::Lua;
+
+log_level('info');
+no_shuffle();
+no_long_string();
+repeat_each(1);
+plan 'no_plan';
+
+our $HttpConfig = <<'_EOC_';
+    lua_package_path 'lib/?.lua;lib/?/init.lua;/usr/local/share/lua/5.3/?.lua;/usr/share/lua/5.1/?.lua;;';
+    resolver 127.0.0.53;
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: basic
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local filter = require("resty.ldap.filter")
+
+            local cases = {
+                {
+                    filter = '(objectClass=*)',
+                    test = (function(f, m)
+                        -- {"item_type":"present","attribute_description":"objectClass","filter_type":"equal","attribute_value":"*"}
+                        assert(type(f) == 'table', m .. 'type != table, ' .. type(f))
+                        assert(f.item_type == 'present', m .. 'item_type != present, ' .. f.item_type)
+                        assert(f.attribute_description == 'objectClass', m .. 'attribute_description != objectClass, ' .. f.attribute_description)
+                        assert(f.filter_type == 'equal', m .. 'filter_type != equal, ' .. f.filter_type)
+                        assert(f.attribute_value == '*', m .. 'attribute_value != *, '.. f.attribute_value)
+                    end),
+                },
+                {
+                    filter = '(objectClass=posixAccount)',
+                    test = (function(f, m)
+                        -- {"attribute_description":"objectClass","item_type":"simple","attribute_value":"posixAccount","filter_type":"equal"}
+                        assert(f.item_type == 'simple', m .. 'item_type != simple, ' .. f.item_type)
+                        assert(f.attribute_value == 'posixAccount', m .. 'attribute_value != posixAccount, ' .. f.attribute_value)
+                    end)
+                },
+                {
+                    filter = '(objectClass=posix*)',
+                    test = (function(f, m)
+                        -- {"item_type":"substring","attribute_value":"posix*","filter_type":"equal","attribute_description":"objectClass"}
+                        assert(f.item_type == 'substring', m .. 'item_type != substring, ' .. f.item_type)
+                        assert(f.attribute_value == 'posix*', m .. 'attribute_value != posix*, ' .. f.attribute_value)
+                    end)
+                },
+                {
+                    filter = '(objectClass=*posix*)',
+                    test = (function(f, m)
+                        -- {"item_type":"substring","attribute_value":"*posix*","filter_type":"equal","attribute_description":"objectClass"}
+                        assert(f.item_type == 'substring', m .. 'item_type != substring, ' .. f.item_type)
+                        assert(f.attribute_value == '*posix*', m .. 'attribute_value != *posix*, ' .. f.attribute_value)
+                    end)
+                },
+                {
+                    filter = '(objectClass=*posix)',
+                    test = (function(f, m)
+                        -- {"item_type":"substring","attribute_value":"*posix","filter_type":"equal","attribute_description":"objectClass"}
+                        assert(f.item_type == 'substring', m .. 'item_type != substring, ' .. f.item_type)
+                        assert(f.attribute_value == '*posix', m .. 'attribute_value != *posix, ' .. f.attribute_value)
+                    end)
+                },
+                {
+                    filter = '(objectClass~=posix)',
+                    test = (function(f, m)
+                        -- {"filter_type":"approx","attribute_description":"objectClass","item_type":"simple","attribute_value":"posix"}
+                        assert(f.filter_type == 'approx', m .. 'filter_type != substring, ' .. f.filter_type)
+                        assert(f.attribute_value == 'posix', m .. 'attribute_value != posix, ' .. f.attribute_value)
+                    end)
+                },
+                {
+                    filter = '(test>=posix)',
+                    test = (function(f, m)
+                        -- {"attribute_value":"posix","filter_type":"greater","attribute_description":"test","item_type":"simple"}
+                        assert(f.filter_type == 'greater', m .. 'filter_type != greater, ' .. f.filter_type)
+                    end)
+                },
+                {
+                    filter = '(test<=posix)',
+                    test = (function(f, m)
+                        -- {"attribute_value":"posix","filter_type":"less","attribute_description":"test","item_type":"simple"}
+                        assert(f.filter_type == 'less', m .. 'filter_type != less, ' .. f.filter_type)
+                    end)
+                },
+            }
+
+            for i, case in ipairs(cases) do
+                local result, err = filter.compile(case.filter)
+                if not result then
+                    assert(false, 'case#' .. i .. ' compile error: ' .. err)
+                end
+                ngx.log(ngx.WARN, cjson.encode(result))
+                case.test(result, 'case#' .. i .. ' error: ')
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 2: operation
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local filter = require("resty.ldap.filter")
+
+            local cases = {
+                {
+                    filter = '(!objectClass=posixAccount)',
+                    test = (function(f, m)
+                        -- {"op_type":"not","items":[{"attribute_value":"posixAccount","item_type":"simple","attribute_description":"objectClass","filter_type":"equal"}]}
+                        assert(f.op_type and f.op_type == 'not', m .. 'op_type != not, ' .. f.op_type)
+                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
+                        assert(f.items[1] ~= nil, m .. 'items not a object table')
+                        assert(f.items[1].attribute_value == 'posixAccount', m .. 'items[1].attribute_value != posixAccount, ' .. f.items[1].attribute_value)
+                    end)
+                },
+                {
+                    filter = '(!(objectClass=posixAccount))',
+                    test = (function(f, m)
+                        -- {"op_type":"not","items":[{"attribute_value":"posixAccount","item_type":"simple","attribute_description":"objectClass","filter_type":"equal"}]}
+                        assert(f.op_type and f.op_type == 'not', m .. 'op_type != not, ' .. f.op_type)
+                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
+                        assert(f.items[1] ~= nil, m .. 'items not a object table')
+                    end)
+                },
+                {
+                    filter = '(&(objectClass=posixAccount)(cn=user01*))',
+                    test = (function(f, m)
+                        -- {"items":[{"attribute_value":"posixAccount","attribute_description":"objectClass","filter_type":"equal","item_type":"simple"},{"attribute_value":"user01*","attribute_description":"cn","filter_type":"equal","item_type":"substring"}],"op_type":"and"}
+                        assert(f.op_type and f.op_type == 'and', m .. 'op_type != and, ' .. f.op_type)
+                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
+                        assert(f.items[2] ~= nil and f.items[3] == nil, m .. 'items not a object table')
+                        assert(f.items[1].item_type == 'simple', m .. 'items[1].item_type != simple, ' .. f.items[1].item_type)
+                        assert(f.items[2].item_type == 'substring', m .. 'items[1].item_type != substring, ' .. f.items[1].item_type)
+                    end)
+                },
+                {
+                    filter = '(|(&(objectClass=posixAccount)(cn=user01*)(uid=*))(&(objectClass=posixGroup)(uid~=user01)))',
+                    test = (function(f, m)
+                        -- {"op_type":"or","items":[{"op_type":"and","items":[{"attribute_value":"posixAccount","attribute_description":"objectClass","filter_type":"equal","item_type":"simple"},{"attribute_value":"user01*","attribute_description":"cn","filter_type":"equal","item_type":"substring"},{"attribute_value":"*","attribute_description":"uid","filter_type":"equal","item_type":"present"}]},{"op_type":"and","items":[{"attribute_value":"posixGroup","attribute_description":"objectClass","filter_type":"equal","item_type":"simple"},{"attribute_value":"user01","attribute_description":"uid","filter_type":"approx","item_type":"simple"}]}]}
+                        assert(f.op_type and f.op_type == 'or', m .. 'op_type != or, ' .. f.op_type)
+                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
+                        assert(f.items[2] ~= nil and f.items[3] == nil, m .. 'items not a object table')
+                        assert(f.items[1].op_type and f.items[1].op_type == 'and', m .. 'items[1].item_type != and, ' .. f.items[1].op_type)
+                        assert(f.items[1].op_type and f.items[2].op_type == 'and', m .. 'items[2].item_type != and, ' .. f.items[2].op_type)
+                        assert(f.items[1].items[2].item_type == 'substring', m .. 'items[1].items[2].item_type != substring, ' .. f.items[1].items[2].item_type)
+                        assert(f.items[1].items[3].item_type == 'present', m .. 'items[1].items[3].item_type != present, ' .. f.items[1].items[3].item_type)
+                        assert(f.items[2].items[2].filter_type == 'approx', m .. 'items[2].items[2].filter_type != approx, ' .. f.items[2].items[2].filter_type)
+                    end)
+                },
+                {
+                    filter = [[
+                        (&
+                            (objectClass=posixAccount)
+                            (uid=*)
+                            (!cn=user01)
+                        )
+                    ]],
+                    test = (function(f, m)
+                        -- {"items":[{"attribute_description":"objectClass","attribute_value":"posixAccount","filter_type":"equal","item_type":"simple"},{"attribute_description":"uid","attribute_value":"*","filter_type":"equal","item_type":"present"},{"items":[{"attribute_description":"cn","attribute_value":"user01","filter_type":"equal","item_type":"simple"}],"op_type":"not"}],"op_type":"and"}
+                        assert(f.op_type and f.op_type == 'and', m .. 'op_type != and, ' .. f.op_type)
+                        assert(f.items and next(f.items) ~= nil, m .. 'items not exist or empty, ' .. cjson.encode(f.items))
+                        assert(f.items[3] ~= nil and f.items[4] == nil, m .. 'items not a object table')
+                        assert(f.items[2].item_type and f.items[2].item_type == 'present', m .. 'items[2].item_type != present, ' .. f.items[2].item_type)
+                        assert(f.items[3].op_type and f.items[3].op_type == 'not', m .. 'items[3].op_type != not, ' .. f.items[3].op_type)
+                    end)
+                }
+            }
+
+            for i, case in ipairs(cases) do
+                local result, err = filter.compile(case.filter)
+                if not result then
+                    assert(false, 'case#' .. i .. ' compile error: ' .. err)
+                end
+                ngx.log(ngx.WARN, cjson.encode(result))
+                case.test(result, 'case#' .. i .. ' error: ')
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200


### PR DESCRIPTION
SearchRequest [1] contains a field called filter, which is also based on the native structure of ASN.1, not just a string.

Users can write expressions to build filters using strings, but we can't pass them directly to the LDAP server, they need to be parsed and encoded into native ASN.1 format.

This PR uses LPeg [2] to implement a compiler front-end that parses user-entered custom string expressions into a custom abstract syntax tree, which is a Lua table, so that we can use it recursively for the ASN.1 encoding process.

[1] https://cwiki.apache.org/confluence/display/DIRxSRVx10/Ldap+ASN.1+Codec#LdapASN.1Codec-SearchRequest
[2] https://luarocks.org/modules/gvvaughan/lpeg