### PR TITLE
feat: improve filter character parser

### DIFF
--- a/lib/resty/ldap/filter.lua
+++ b/lib/resty/ldap/filter.lua
@@ -1,8 +1,9 @@
 local lpeg = require('lpeg')
 local P, R, S, V = lpeg.P, lpeg.R, lpeg.S, lpeg.V
-local C, Ct, Cmt, Cg, Cc, Cf, Cmt = lpeg.C, lpeg.Ct, lpeg.Cmt, lpeg.Cg, lpeg.Cc, lpeg.Cf, lpeg.Cmt
+local C, Ct, Cmt, Cg, Cp, Cc, Cf = lpeg.C, lpeg.Ct, lpeg.Cmt, lpeg.Cg, lpeg.Cp, lpeg.Cc, lpeg.Cf
 
 local string_char = string.char
+local string_sub = string.sub
 local table_insert = table.insert
 local table_concat = table.concat
 
@@ -65,19 +66,14 @@ local cItemBody = function(item_type_hint, ...)
     }
 end
 
--- Simple types
-local rawValue = (P'_' + R'09' + R('az', 'AZ')) * (P'_' + R'09' + R('az', 'AZ')) ^ 0
-
 -- Grammar
 local filter = P{
-    V'FILTER' / function(f)
-        return f
-    end,
+    'FILTER',
     FILTER = V'FILL' * P'(' * V'OP' * P')' * V'FILL' / function(f)
         return f
     end,
 
-    OP= (V'OP_AND' + V'OP_OR' + V'OP_NOT' + V'ITEM'),
+    OP = (V'OP_AND' + V'OP_OR' + V'OP_NOT' + V'ITEM'),
     OP_AND = (P'&' * V'FILL' * list('FILTER', 1) * V'FILL') / function(...)
         return cOPBody(_M.OP_TYPE_AND, ...)
     end,
@@ -109,10 +105,10 @@ local filter = P{
         return { filter_type = _M.FILTER_TYPE_LESS }
     end,
 
-    ATTRIBUTE_DESCRIPTION = rawValue / function(value)
+    ATTRIBUTE_DESCRIPTION = V'RAW_VALUE' / function(value)
         return { attribute_description = value }
     end,
-    ATTRIBUTE_VALUE = rawValue / function(value)
+    ATTRIBUTE_VALUE = V'RAW_VALUE' / function(value)
         return { attribute_value = value }
     end,
     ATTRIBUTE_VALUE_SUBSTRING = (
@@ -124,7 +120,7 @@ local filter = P{
         local s = {}
         for i = 1, select('#', ...) do
             local v = select(i, ...)
-            if v.attribute_value then
+            if v.attribute_value and v.attribute_value ~= "" then
                 table_insert(s, v.attribute_value)
             elseif #v > 0 and v[1] then -- check if the elements are arrays
                 -- When there is the following format xxx*a*b*c*xxx,
@@ -138,15 +134,50 @@ local filter = P{
         return { attribute_value = s }
     end,
 
+    RAW_VALUE = list(V'ESCAPED_CHARACTER' + V'UTF8_FILTERED_CHARACTER') / table_concat, -- UTF8 sequence
+    DIGIT = R'09',
     WILDCARD = P'*' / function()
         return { attribute_value = "*" }
     end,
+    ESCAPED_CHARACTER = P'\\' * V'ASCII_VALUE',
+    ASCII_VALUE = V'HEX_CHAR' * V'HEX_CHAR' / function(value)
+        return string_char(tonumber(value, 16))
+    end,
+    HEX_CHAR = R('af', 'AF', '09'),
     FILL = list(V'SPACE' + V'TAB' + V'SEP', 0) / function() end,
-    SPACE = P(string_char(0x20)),         -- ASCII control charactor - Space
-    TAB = P(string_char(0x09)),           -- ASCII control charactor - TAB
-    SEP= (V'CR' * V'LF') + V'CR' + V'LF', -- ASCII control charactor - CR/LF/CRLF
-    CR = P'\r',                           -- ASCII control charactor - CR
-    LF = P'\n',                           -- ASCII control charactor - LF
+    SPACE = P(string_char(0x20)),         -- ASCII control character - Space
+    TAB = P(string_char(0x09)),           -- ASCII control character - TAB
+    SEP= (V'CR' * V'LF') + V'CR' + V'LF', -- ASCII control character - CR/LF/CRLF
+    CR = P'\r',                           -- ASCII control character - CR
+    LF = P'\n',                           -- ASCII control character - LF
+
+    UTF8_CONT = R'\128\191', -- continuation byte
+    UTF8_FILTERED_CHARACTER =
+        -- Handle some cases where exclusion symbols are not need.
+        -- If attribute and value contain struck-out characters, but they are not part of any
+        -- operator, capture and skip it without enabling subsequent HEX-based matches
+        -- (since these characters are part of value, but HEX matches will unconditionally
+        -- strike them out)
+        Cmt(R('\0\127'), function(s, i, prev) -- match all ASCII character
+            -- Make sure that this character is not the last character, only then it is
+            -- possible to compose the operator.
+            if #s <= i + 1 then 
+                return false
+            end
+
+            -- Ensures that the value is parsed properly if there is a separate ~ symbol in the value.
+            if string_sub(s, i, i) == '~' and string_sub(s, i + 1, i + 1) ~= "=" then
+                -- Captures and skips that ~ symbol. The previous capture element needs to be 
+                -- added back manually.
+                return i + 1, prev .. '~'
+            end
+
+            return false -- No capture by default
+        end)
+        + R("\0\39", "\43\59", "\63\125", "\127\127") / "%0" -- 1-byte character, remove (, ), <, >, *, =, ~
+        + R("\194\223") * V'UTF8_CONT' / "%0" -- 2-byte character
+        + R("\224\239") * V'UTF8_CONT' * V'UTF8_CONT' / "%0" -- 3-byte character
+        + R("\240\244") * V'UTF8_CONT' * V'UTF8_CONT' * V'UTF8_CONT' / "%0", -- 4-byte character
 }
 
 

--- a/t/filter.t
+++ b/t/filter.t
@@ -72,7 +72,7 @@ __DATA__
                 {
                     filter = '(objectClass~=posix)',
                     test = (function(f, m)
-                        assert(f.filter_type == 'approx', m .. 'filter_type != substring, ' .. f.filter_type)
+                        assert(f.filter_type == 'approx', m .. 'filter_type != approx, ' .. f.filter_type)
                         assert(f.attribute_value == 'posix', m .. 'attribute_value != posix, ' .. f.attribute_value)
                     end)
                 },
@@ -292,6 +292,154 @@ GET /t
                 end
                 ngx.log(ngx.WARN, cjson.encode(result))
                 case.test(result, 'case#' .. i .. ' error: ')
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_code: 200
+
+
+
+=== TEST 4: go-ldap cases
+Implement the filter compilation test in https://github.com/go-ldap/ldap,
+removing the extensible match implementation from it.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local filter = require("resty.ldap.filter")
+            local to_hex = require("resty.string").to_hex
+            local asn1_encode = require("resty.ldap.asn1").encode
+
+            local cases = {
+                {-- #1
+                    filter = '(&(sn=Miller)(givenName=Bob))'
+                },
+                {-- #2
+                    filter = '(|(sn=Miller)(givenName=Bob))'
+                },
+                {-- #3
+                    filter = '(sn=Miller)'
+                },
+                {-- #4
+                    filter = '(sn=Mill*)'
+                },
+                {-- #5
+                    filter = '(sn=*Mill)'
+                },
+                {-- #6
+                    filter = '(sn=*Mill*)'
+                },
+                {-- #7
+                    filter = '(sn=*i*le*)'
+                },
+                {-- #8
+                    filter = '(sn=Mi*l*r)'
+                },
+                {-- #9
+                    filter = '(sn=Mi*함*r)',
+                    test = (function(f, m)
+                        assert(type(f.attribute_value) == 'table', m .. 'attribute_value not a table, ' .. type(f.attribute_value))
+                        local str = table.concat(f.attribute_value)
+                        assert(str == 'Mi*함*r', m .. 'attribute_value not equal to Mi*함*r, ' .. str)
+                        assert(to_hex(str) == '4d692aed95a82a72', m .. 'attribute_value in hex not equal to 4d692aed95a82a72, ' .. to_hex(str))
+                    end),
+                },
+                {-- #10
+                    filter = '(sn=Mi*\\ed\\95\\a8*r)',
+                    test = (function(f, m)
+                        assert(type(f.attribute_value) == 'table', m .. 'attribute_value not a table, ' .. type(f.attribute_value))
+                        local str = table.concat(f.attribute_value)
+                        assert(str == 'Mi*함*r', m .. 'attribute_value not equal to Mi*함*r, ' .. str)
+                        assert(to_hex(str) == '4d692aed95a82a72', m .. 'attribute_value in hex not equal to 4d692aed95a82a72, ' .. to_hex(str))
+                    end),
+                },
+                {-- #11
+                    filter = '(sn=Mi*le*)'
+                },
+                {-- #12
+                    filter = '(sn=*i*ler)'
+                },
+                {-- #13
+                    filter = '(sn>=Miller)'
+                },
+                {-- #14
+                    filter = '(sn<=Miller)'
+                },
+                {-- #15
+                    filter = '(sn=*)'
+                },
+                {-- #16
+                    filter = '(sn~=Miller)'
+                },
+                {-- #17 27fcfea3abf9904eaa476dd57ed132
+                    filter = "(objectGUID='\\fc\\fe\\a3\\ab\\f9\\90N\\aaGm\\d5I~\\d12)",
+                    test = (function(f, m)
+                        local str = f.attribute_value
+                        assert(to_hex(str) == '27fcfea3abf9904eaa476dd5497ed132', m .. 'attribute_value in hex not equal to 27fcfea3abf9904eaa476dd5497ed132, ' .. to_hex(str))
+                    end),
+                },
+                {-- #18
+                    filter = '(objectGUID=абвгдеёжзийклмнопрстуфхцчшщъыьэюя)',
+                    test = (function(f, m)
+                        local target = 'd0b0d0b1d0b2d0b3d0b4d0b5d191d0b6d0b7d0b8d0b9d0bad0bbd0bcd0bdd0bed0bfd180d181d182d183d184d185d186d187d188d189d18ad18bd18cd18dd18ed18f'
+                        local str = f.attribute_value
+                        assert(str == 'абвгдеёжзийклмнопрстуфхцчшщъыьэюя', m .. 'attribute_value not equal to абвгдеёжзийклмнопрстуфхцчшщъыьэюя, ' .. str)
+                        assert(
+                            to_hex(str) == target,
+                            m .. 'attribute_value in hex not equal to ' .. target .. ', ' .. to_hex(str)
+                        )
+                    end),
+                },
+                {-- #19
+                    filter = '(objectGUID=함수목록)',
+                    test = (function(f, m)
+                        local str = f.attribute_value
+                        assert(str == '함수목록', m .. 'attribute_value not equal to 함수목록, ' .. str)
+                        assert(to_hex(str) == 'ed95a8ec8898ebaaa9eba19d', m .. 'attribute_value in hex not equal to ed95a8ec8898ebaaa9eba19d, ' .. to_hex(str))
+                    end),
+                },
+                {-- #20
+                    filter = '(objectGUID=',
+                    expect_err = "syntax error",
+                },
+                {-- #21
+                    filter = '(objectGUID=함수목록',
+                    expect_err = "syntax error",
+                },
+                {-- #22
+                    filter = '((cn=)',
+                    expect_err = "syntax error",
+                },
+                {-- #23
+                    filter = '(&(objectclass=inetorgperson)(cn=中文))',
+                    test = (function(f, m)
+                        local str = f.items[2].attribute_value
+                        assert(f.op_type == 'and', m .. 'op_type not equal to and, ' .. f.op_type)
+                        assert(#f.items == 2 and str == '中文', m .. 'items[2].attribute_value not equal to 中文, ' .. str)
+                    end),
+                },
+            }
+
+            for i, case in ipairs(cases) do
+                local result, err = filter.compile(case.filter)
+                if not result then
+                    if case.expect_err then
+                        assert(case.expect_err == err, 
+                                'case#' .. i .. ' error content does not match expectations, expect: '
+                                .. case.expect_err .. ', actual: ' .. err)
+                    else
+                        assert(false, 'case#' .. i .. ' compile error: ' .. err)
+                    end
+                end
+                ngx.log(ngx.WARN, cjson.encode(result))
+                if case.test then
+                    case.test(result, 'case#' .. i .. ' error: ')
+                end
             end
         }
     }


### PR DESCRIPTION
In the previous implementation, both AttributeType and AttributeValue only supported values in the range `0-9 a-z A-Z`, which was not enough, in fact its value could be almost any character that does not involve a filter operator, which also contains parts of non-ASCII characters, such as CJK and Cyrillic, etc. (they can all be represented in Unicode which occupies 3byte space, so using HEX can represent them, like `\xx\xx\xx`), this PR changes the status quo and starts matching from the characters, it supports those characters themselves and their HEX forms. This PR does not substantially modify the original filter test cases and uses test-driven development on the new features; these changes are fully backward compatible.

BTW, it has not been added yet for testing in real search case, because we cannot currently send some special requests to change the data in OpenLDAP, next I will implement and export a special operation function on the client called `_unknown`, which allows the user to send a HEX-encoded data body directly without understanding the essence of the protocol, it will be used for testing, such as modifying an item to add a new attribute. At the moment we can't implement it because `_send_receive` is not exported (and it shouldn't be). A test with Chinese values passed locally, so I think this PR modification is working fine.

Update: test cases here: https://github.com/api7/lua-resty-ldap/pull/9