### PR TITLE
chore: let pool configuration use keepalive prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To load this module:
 | `start_tls`           | boolean      | false      | Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over ldap connection. If the start_tls setting is enabled, ensure the ldaps setting is disabled.       |
 | `ldaps`               | boolean      | false      | Set to `true` to connect using the LDAPS protocol (LDAP over TLS). When ldaps is configured, you must use port 636. If the ldap setting is enabled, ensure the start_tls setting is disabled.       |
 | `ssl_verify`          | boolean      | false      | Set to true to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.       |
-| `pool_name`           | string       | host:ip  | Set and override the default connection pool name for scenarios where the same connection parameters are used but with a different authentication method. The default value is the same as the OpenResty rule, and the value is the `host:port` of the LDAP server. |
-| `pool_size`           | number       | 2          | Set the size of a certain connection pool. According to OpenResty's rule, it can only be set when the pool is created and cannot be changed dynamically. |
+| `keepalive_pool_name`           | string       | host:ip  | Set and override the default connection pool name for scenarios where the same connection parameters are used but with a different authentication method. The default value is the same as the OpenResty rule, and the value is the `host:port` of the LDAP server. |
+| `keepalive_pool_size`           | number       | 2          | Set the size of a certain connection pool. According to OpenResty's rule, it can only be set when the pool is created and cannot be changed dynamically. |
 
 #### simple_bind
 

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -94,12 +94,12 @@ local function _init_socket(self)
     -- connections and vice-versa, because STARTTLS use the same port
     local opts = {
         pool = host .. ":" .. port .. (socket_config.start_tls and ":starttls" or ""),
-        pool_size = socket_config.pool_size,
+        pool_size = socket_config.keepalive_pool_size,
     }
 
     -- override the value when the user specifies connection pool name
-    if socket_config.pool_name and socket_config.pool_name ~= "" then
-        opts.pool = socket_config.pool_name
+    if socket_config.keepalive_pool_name and socket_config.keepalive_pool_name ~= "" then
+        opts.pool = socket_config.keepalive_pool_name
     end
 
     local ok, err = sock:connect(host, port, opts)
@@ -229,8 +229,8 @@ function _M.new(_, host, port, client_config)
         -- Specify the connection pool name directly to ensure that connections
         -- with the same connection parameters but using different authentication
         -- methods are not put into the same pool.
-        pool_name = opts.pool_name or nil,
-        pool_size = opts.pool_size or 2,
+        keepalive_pool_name = opts.keepalive_pool_name or nil,
+        keepalive_pool_size = opts.keepalive_pool_size or 2,
     }
 
     local cli = setmetatable({


### PR DESCRIPTION
The connection pool in the current client configuration starts with `pool_`, which I thought was misleading, so I added the `keepalive_` prefix to it.
| From | To |
|-------|----|
| pool_name | keepalive_pool_name |
| pool_size | keepalive_pool_size |