### PR TITLE
chore: change default search filter to (objectClass=*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ To load this module:
 
 `types_only` indicates whether search result entries should only include attribute descriptions (attribute type names or OIDs, followed by zero or more attribute options), rather than both attribute descriptions and values. This is a Boolean element. Default is `false`.
 
-`filter` is an LDAP filter expression in string. Default is `(objectClass=posixAccount)`.
+`filter` is an LDAP filter expression in string. Default is `(objectClass=*)`.
 
 `attributes` is an array table that contains one to more query fields that you need to have the LDAP server return. Default is `["objectClass"]`.

--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -275,7 +275,7 @@ function _M.search(self, base_dn, scope, deref_aliases, size_limit, time_limit,
         size_limit    or 0, -- size limit
         time_limit    or 0, -- time limit
         types_only    or false, -- type only
-        filter        or "(objectClass=posixAccount)", -- filter
+        filter        or "(objectClass=*)", -- filter
         attributes    or {"objectClass"} -- attr
     )
     if not search_req then


### PR DESCRIPTION
For the default value of the search filter, we should make it able to match any type of item. so make this change.