### PR TITLE
fix: global variable assignment

### DIFF
--- a/lib/resty/ldap/client.lua
+++ b/lib/resty/ldap/client.lua
@@ -133,7 +133,7 @@ local function _init_socket(self)
     end
 
     if socket_config.start_tls or socket_config.ldaps then
-        _, err = sock:sslhandshake(true, host, socket_config.ssl_verify)
+        local _, err = sock:sslhandshake(true, host, socket_config.ssl_verify)
         if err ~= nil then
             return fmt("do TLS handshake on %s:%s failed: %s",
                         host, tostring(port), err)


### PR DESCRIPTION
This PR fixes a global variable assignment in resty/ldap/client.lua.
The variable _ was previously declared without local, which caused it to leak into the global scope.

Under OpenResty (my usecase), this can lead to race conditions between concurrent requests.