### PR TITLE
feat: pure-Lua LDAP search (drop Rust rasn) — RFC #116 slice 1

### DIFF
--- a/lib/resty/ldap/asn1.lua
+++ b/lib/resty/ldap/asn1.lua
@@ -2,11 +2,16 @@ local ffi          = require("ffi")
 local C            = ffi.C
 local ffi_new      = ffi.new
 local ffi_string   = ffi.string
+local ffi_cast     = ffi.cast
+local band         = require("bit").band
 local string_char  = string.char
+local string_sub   = string.sub
+local table_insert = table.insert
 local new_tab      = require("resty.core.base").new_tab
 
 local ucharpp      = ffi_new("unsigned char*[1]")
 local charpp       = ffi_new("char*[1]")
+local cucharpp     = ffi_new("const unsigned char*[1]")
 
 
 ffi.cdef [[
@@ -159,6 +164,119 @@ do
     end
 end
 _M.encode = encode
+
+
+local MAX_DECODE_DEPTH = 100
+
+local asn1_get_object
+do
+    local lenp   = ffi_new("long[1]")
+    local tagp   = ffi_new("int[1]")
+    local classp = ffi_new("int[1]")
+    local strpp  = ffi_new("const unsigned char*[1]")
+
+    function asn1_get_object(der, start, stop)
+        start = start or 0
+        stop = stop or #der
+        if stop <= start or stop > #der then
+            return nil, "invalid offset"
+        end
+
+        local s_der = ffi_cast("const unsigned char *", der)
+        strpp[0] = s_der + start
+
+        local ret = C.ASN1_get_object(strpp, lenp, tagp, classp, stop - start)
+        -- The 0x80 bit signals an encoding error (also set for the illegal
+        -- indefinite/too-long forms). Reject rather than trust the result.
+        if band(ret, 0x80) == 0x80 or band(ret, 0x01) == 0x01 then
+            return nil, "invalid BER: bad tag/length encoding"
+        end
+
+        local content_off = strpp[0] - s_der
+        return {
+            tag    = tagp[0],
+            class  = classp[0],
+            len    = tonumber(lenp[0]),
+            offset = content_off,           -- 0-indexed content start
+            hl     = content_off - start,   -- header length (fixes the hardcoded +2)
+            cons   = band(ret, 0x20) == 0x20,
+        }
+    end
+end
+_M.get_object = asn1_get_object
+
+
+local decode
+do
+    local decoder = new_tab(0, 5)
+
+    -- OCTET STRING: slice raw content bytes directly. Binary/NUL-safe by
+    -- construction (no strlen-based ffi_string, no d2i).
+    decoder[TAG.OCTET_STRING] = function(der, _, obj)
+        return string_sub(der, obj.offset + 1, obj.offset + obj.len)
+    end
+
+    -- INTEGER / ENUMERATED: d2i parses a full TLV, so `offset` is the TLV start.
+    decoder[TAG.INTEGER] = function(der, offset, obj)
+        cucharpp[0] = ffi_cast("const unsigned char *", der) + offset
+        local typ = C.d2i_ASN1_INTEGER(nil, cucharpp, obj.hl + obj.len)
+        if typ == nil then
+            return nil
+        end
+        local v = C.ASN1_INTEGER_get(typ)
+        C.ASN1_INTEGER_free(typ)
+        return tonumber(v)
+    end
+
+    decoder[TAG.ENUMERATED] = function(der, offset, obj)
+        cucharpp[0] = ffi_cast("const unsigned char *", der) + offset
+        local typ = C.d2i_ASN1_ENUMERATED(nil, cucharpp, obj.hl + obj.len)
+        if typ == nil then
+            return nil
+        end
+        local v = C.ASN1_ENUMERATED_get(typ)
+        C.ASN1_INTEGER_free(typ)   -- shares the ASN1_STRING struct; INTEGER_free is correct
+        return tonumber(v)
+    end
+
+    local function decode_children(der, _, obj, depth)
+        local stop = obj.offset + obj.len
+        local pos = obj.offset
+        local values = {}
+        while pos < stop do
+            local value, err
+            pos, value, err = decode(der, pos, depth + 1)
+            if err then
+                return nil
+            end
+            table_insert(values, value)
+        end
+        return values
+    end
+
+    decoder[TAG.SEQUENCE] = decode_children
+    decoder[TAG.SET]      = decode_children
+
+    -- offset is 0-indexed. Returns next_offset, value, err.
+    function decode(der, offset, depth)
+        offset = offset or 0
+        depth = depth or 0
+        if depth > MAX_DECODE_DEPTH then
+            return nil, nil, "max decode depth exceeded"
+        end
+        local obj, err = asn1_get_object(der, offset)
+        if not obj then
+            return nil, nil, err
+        end
+        local d = decoder[obj.tag]
+        local value
+        if d then
+            value = d(der, offset, obj, depth)
+        end
+        return obj.offset + obj.len, value
+    end
+end
+_M.decode = decode
 
 
 return _M

--- a/t/asn1.t
+++ b/t/asn1.t
@@ -1,0 +1,130 @@
+use Test::Nginx::Socket::Lua;
+
+log_level('info');
+no_shuffle();
+no_long_string();
+repeat_each(1);
+plan 'no_plan';
+
+our $HttpConfig = <<'_EOC_';
+    lua_package_path 'lib/?.lua;/usr/share/lua/5.1/?.lua;;';
+    lua_package_cpath 'deps/lib/lua/5.1/?.so;;';
+    resolver 127.0.0.53;
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: get_object reads tag/class/len/hl for short and long form
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local asn1 = require("resty.ldap.asn1")
+            local function h(s) return (s:gsub("%s+",""):gsub("%x%x", function(b) return string.char(tonumber(b,16)) end)) end
+
+            -- short form: 30 03 02 01 05  (SEQUENCE len 3)
+            local o = assert(asn1.get_object(h("30 03 02 01 05")))
+            assert(o.tag == 16, "tag " .. o.tag)          -- SEQUENCE
+            assert(o.class == asn1.CLASS.UNIVERSAL, "class")
+            assert(o.cons == true, "cons")
+            assert(o.len == 3, "len " .. o.len)
+            assert(o.hl == 2, "hl " .. o.hl)
+            assert(o.offset == 2, "offset " .. o.offset)
+
+            -- long form: 30 81 82 <130 bytes>  (2-extra-byte header)
+            local body = string.rep("\0", 130)
+            local o2 = assert(asn1.get_object(h("30 81 82") .. body))
+            assert(o2.len == 130, "long len " .. o2.len)
+            assert(o2.hl == 3, "long hl " .. o2.hl)       -- NOT 2
+
+            -- application-tagged: 64 00  (SearchResultEntry, empty)
+            local o3 = assert(asn1.get_object(h("64 00")))
+            assert(o3.tag == 4, "app tag " .. o3.tag)
+            assert(o3.class == asn1.CLASS.APPLICATION, "app class")
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+=== TEST 2: decode octet string is NUL-safe (regression: no strlen truncation)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local asn1 = require("resty.ldap.asn1")
+            local function h(s) return (s:gsub("%s+",""):gsub("%x%x", function(b) return string.char(tonumber(b,16)) end)) end
+            -- 04 05 41 42 00 43 44  => "AB\0CD" (5 bytes, embedded NUL)
+            local _, v = asn1.decode(h("04 05 41 42 00 43 44"))
+            assert(#v == 5, "length " .. #v)               -- would be 2 under the old strlen bug
+            assert(v == "AB\0CD", "value")
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+=== TEST 3: decode integer, enumerated, and nested SEQUENCE/SET (uses hl, not +2)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local asn1 = require("resty.ldap.asn1")
+            local function h(s) return (s:gsub("%s+",""):gsub("%x%x", function(b) return string.char(tonumber(b,16)) end)) end
+
+            local _, id = asn1.decode(h("02 01 03"))
+            assert(id == 3, "int " .. tostring(id))
+            local _, code = asn1.decode(h("0a 01 00"))
+            assert(code == 0, "enum " .. tostring(code))
+
+            -- SET OF two octet strings: 31 0d 04 03 746f70 04 06 646f6d61696e
+            local _, vals = asn1.decode(h("31 0d 04 03 74 6f 70 04 06 64 6f 6d 61 69 6e"))
+            assert(type(vals) == "table", "set is table")
+            assert(vals[1] == "top" and vals[2] == "domain", "set values")
+
+            -- long-form SET (>=128 bytes of content) parses via hl, not +2
+            local big = string.rep("\4\1X", 60)          -- 60 octet strings "X" = 180 bytes
+            local seq = h("31 81 b4") .. big              -- 0xb4 = 180
+            local _, arr = asn1.decode(seq)
+            assert(#arr == 60, "long set count " .. #arr)
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+
+=== TEST 4: malformed input returns error, never crashes
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local asn1 = require("resty.ldap.asn1")
+            local function h(s) return (s:gsub("%s+",""):gsub("%x%x", function(b) return string.char(tonumber(b,16)) end)) end
+            -- claims 5 content bytes, only 2 present
+            local off, v, err = asn1.decode(h("30 05 02 01"))
+            assert(v == nil, "no value on malformed")
+            assert(err ~= nil, "error reported")
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]


### PR DESCRIPTION
Slice 1 of the LDAP-Auth-Advanced work (RFC api7/rfcs#116): make the LDAP response path pure Lua so `lua-resty-ldap` can drop the Rust `rasn` dependency (apache/apisix#9891) while gaining `search`.

Landing incrementally, one reviewable commit per step. **Draft — in progress.**

Done so far:
- Pure-Lua BER decode primitives (`asn1.get_object` / `asn1.decode`): NUL-safe octet-string reads, header-length-based structural walk, indefinite-length rejection, recursion-depth guard (`t/asn1.t`).

Still to come: message-level decoder, `client.lua` on the Lua decoder, connection-pinning session, RFC 4515 filter escaping, `ldap-auth` compat modules, Rust removal + pure-Lua rockspec, AD-shaped fixture tests.
